### PR TITLE
Fix dexOffset in findPos; Fix classData Size.

### DIFF
--- a/dex/dex2dex/include/d2d_l2d.h
+++ b/dex/dex2dex/include/d2d_l2d.h
@@ -96,6 +96,7 @@ struct D2Dpool
     UInt32 dexAnnotationsDirectoryOff;
     UInt32 annotationsDirectorySize;
     UInt32 annotationsDirectoryOff;
+    UInt32 updateClassDataSize;
 
 };
 

--- a/dex/lir/src/drcode.c
+++ b/dex/lir/src/drcode.c
@@ -709,6 +709,11 @@ bool d2rMethod(D2Dpool* pool, DexFile* pDexFile, const DexMethod* pDexMethod)
                     break;
             }
             codePtr += width;
+            if (codePtr >= codeEnd)
+            {
+                // do not update dexOffset for the end
+                break;
+            }
             dexOffset += width;
             continue;
         }


### PR DESCRIPTION
1. The pseudo code match will cause false dexOffset in the end.
2. classData Size is not coherent in clsnumber and item->size.
